### PR TITLE
Getting rid of dstore patches &&  Update client libs

### DIFF
--- a/src/main/javascript/lyra/package.json
+++ b/src/main/javascript/lyra/package.json
@@ -1,7 +1,7 @@
 {
   "name": "lyra-grid",
   "author": "CourseIT",
-  "version": "1.0.1",
+  "version": "1.0.",
   "description": "Lyra-client is a client counterpart of Lyra Grid",
   "license": "LGPL-3.0",
   "repository": {
@@ -22,7 +22,7 @@
     "curs"
   ],
   "dependencies": {
-    "dgrid": "^1.1.0",
+    "dgrid": "^1.2.1",
     "dojo-dstore": "^1.1.2",
     "dojo": "^1.15.0",
     "vue": "^2.5.2",

--- a/src/main/javascript/lyra/package.json
+++ b/src/main/javascript/lyra/package.json
@@ -1,7 +1,7 @@
 {
   "name": "lyra-grid",
   "author": "CourseIT",
-  "version": "1.0.",
+  "version": "1.0.1",
   "description": "Lyra-client is a client counterpart of Lyra Grid",
   "license": "LGPL-3.0",
   "repository": {
@@ -22,7 +22,7 @@
     "curs"
   ],
   "dependencies": {
-    "dgrid": "^1.2.1",
+    "dgrid": "^1.1.0",
     "dojo-dstore": "^1.1.2",
     "dojo": "^1.15.0",
     "vue": "^2.5.2",

--- a/src/main/javascript/lyra/package.json
+++ b/src/main/javascript/lyra/package.json
@@ -1,7 +1,7 @@
 {
   "name": "lyra-grid",
   "author": "CourseIT",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Lyra-client is a client counterpart of Lyra Grid",
   "license": "LGPL-3.0",
   "repository": {
@@ -22,7 +22,7 @@
     "curs"
   ],
   "dependencies": {
-    "dgrid": "^1.2.1",
+    "dgrid": "^1.1.0",
     "dojo-dstore": "^1.1.2",
     "dojo": "^1.15.0",
     "vue": "^2.5.2",

--- a/src/main/javascript/lyra/package.json
+++ b/src/main/javascript/lyra/package.json
@@ -17,6 +17,7 @@
     "scroll",
     "form",
     "table",
+    "table",
     "vue",
     "course",
     "curs"

--- a/src/main/javascript/lyra/package.json
+++ b/src/main/javascript/lyra/package.json
@@ -1,7 +1,7 @@
 {
   "name": "lyra-grid",
   "author": "CourseIT",
-  "version": "1.0.",
+  "version": "1.0.0",
   "description": "Lyra-client is a client counterpart of Lyra Grid",
   "license": "LGPL-3.0",
   "repository": {
@@ -16,7 +16,6 @@
     "data",
     "scroll",
     "form",
-    "table",
     "table",
     "vue",
     "course",


### PR DESCRIPTION
## Overview

1. Getting rid of dstore patches
2. Update client libs

---

### Checklist

- [x] Change is covered by automated tests.
- [x] JavaDoc documentation is provided for all public APIs.
- [x] Adequate additions/corrections made to User Guide.
- [x] All CI builds pass.
