### PR TITLE
Update Celesta to 7.1.00

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -60,7 +60,7 @@
         <spring.boot.version>2.0.6.RELEASE</spring.boot.version>
         <spring.boot.websocket.version>2.0.6.RELEASE</spring.boot.websocket.version>
         <spring.boot.starter.celesta.version>2.0.1</spring.boot.starter.celesta.version>
-        <celesta.version>7.0.18</celesta.version>
+        <celesta.version>7.1.00</celesta.version>
         <jacoco.version>0.8.1</jacoco.version>
     </properties>
 
@@ -196,7 +196,6 @@
                 <executions>
                     <execution>
                         <goals>
-                            <goal>gen-cursors</goal>
                             <goal>gen-test-cursors</goal>
                         </goals>
                     </execution>

--- a/src/test/java/ru/curs/lyra/kernel/TestLyraForm.java
+++ b/src/test/java/ru/curs/lyra/kernel/TestLyraForm.java
@@ -5,7 +5,6 @@ import ru.curs.celesta.CallContext;
 import ru.curs.celesta.dbutils.BasicCursor;
 import ru.curs.celesta.score.*;
 import ru.curs.celesta.score.io.FileResource;
-import ru.curs.celesta.score.io.Resource;
 
 import java.io.File;
 import java.io.FileInputStream;

--- a/src/test/java/ru/curs/lyra/kernel/TestLyraForm.java
+++ b/src/test/java/ru/curs/lyra/kernel/TestLyraForm.java
@@ -4,6 +4,8 @@ import org.junit.jupiter.api.Test;
 import ru.curs.celesta.CallContext;
 import ru.curs.celesta.dbutils.BasicCursor;
 import ru.curs.celesta.score.*;
+import ru.curs.celesta.score.io.FileResource;
+import ru.curs.celesta.score.io.Resource;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -87,7 +89,7 @@ public class TestLyraForm {
         ) {
             CelestaParser cp1 = new CelestaParser(is1, "utf-8");
             CelestaParser cp2 = new CelestaParser(is2, "utf-8");
-            GrainPart gp = cp1.extractGrainInfo(s, f);
+            GrainPart gp = cp1.extractGrainInfo(s, new FileResource(f));
             g = cp2.parseGrainPart(gp);
         }
 


### PR DESCRIPTION
## Overview

Update Celesta to 7.1.00

---

### Checklist

- [x] Change is covered by automated tests.
- [x] JavaDoc documentation is provided for all public APIs.
- [x] Adequate additions/corrections made to User Guide.
- [x] All CI builds pass.
