### PR TITLE
Implement returning JDBC connection to pool during blocked wait

### DIFF
--- a/src/main/java/ru/curs/lyra/kernel/grid/GridDriver.java
+++ b/src/main/java/ru/curs/lyra/kernel/grid/GridDriver.java
@@ -51,15 +51,12 @@ public final class GridDriver {
      * A closed copy of underlying cursor that handles filters and sorting.
      */
     private final BasicCursor closedCopy;
+    private final List<String> columns;
 
     private int smallScroll = DEFAULT_SMALL_SCROLL;
 
     private final class Counter extends RefinementScheduler {
         private BasicCursor c;
-        private final List<String> columns =
-                Arrays.stream(closedCopy.orderByColumnNames())
-                        .map(WhereTermsMaker::unquot)
-                        .collect(Collectors.toList());
 
         @Override
         protected boolean refineInterpolator() {
@@ -165,6 +162,9 @@ public final class GridDriver {
             }
         };
 
+        columns = Arrays.stream(closedCopy.orderByColumnNames())
+                .map(WhereTermsMaker::unquot)
+                .collect(Collectors.toList());
         executorService.submit(counter);
     }
 


### PR DESCRIPTION
## Overview

Async refiner process as implemented earlier used only one JDBC connection, obtained during its intitialization. This is not going to work: any JDBC connection become invalid during some time. Besides that, it is not optimal to hold a connection during blocked wait of another refinement task.

I implemented the following: during blocked waiting the connection is returned to the pool. After obtaining another task we re-initialize `CallContext`.

---

### Checklist

- [X] Change is covered by automated tests.
- N/A [ ] JavaDoc documentation is provided for all public APIs.
- N/A [ ] Adequate additions/corrections made to User Guide.
- [X] All CI builds pass.
